### PR TITLE
Dev port & API styles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     volumes:
       - ./proxy/nginx.conf:/etc/nginx/nginx.conf
     ports:
-      - 80:80
+      - 5000:80
     depends_on:
       - backend
       - frontend

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -36,6 +36,11 @@ http {
 			proxy_pass http://backend:8000;
 			proxy_set_header Host $host;
 		}
+
+        location /backend_static {
+			proxy_pass http://backend:8000;
+			proxy_set_header Host $host;
+        }
 		
 		location /admin {
 			proxy_pass http://backend:8000;


### PR DESCRIPTION
1. A Docker for Desktop-os kubernetes cluster a 80-as localhost porton fut, így célszerűbb az egyéb fejlesztőkörnyezeteket más, pl. az 5000-es porton futtatni.
2. A DRF API böngészős oldalai ocsmányul jelentek meg, mert a /backend_static útvonalon található stílus és egyéb js fájlokat a böngésző a frontend conteinerben kereste.